### PR TITLE
[WIP] Allow overriding sidecar memory limit from a workspace config attributes

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -502,6 +502,10 @@ che.singleport.wildcard_domain.ipless=false
 # plugins dependencies to a workspace
 che.workspace.plugin_broker.image=eclipse/che-plugin-broker:latest
 
+# Docker image of Che plugin broker app that resolves workspace tooling configuration and copies
+# plugins dependencies to a workspace
+che.workspace.plugin_broker.pull_policy=Always
+
 # Workspace tooling plugins registry endpoint. Should be a valid HTTP URL.
 # Example: http://che-plugin-registry-eclipse-che.192.168.65.2.nip.io
 # In case Che plugins tooling is not needed value 'NULL' should be used

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesPluginsToolingApplier.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesPluginsToolingApplier.java
@@ -102,6 +102,7 @@ public class KubernetesPluginsToolingApplier implements ChePluginsApplier {
             .setContainer(k8sContainer)
             .setContainerEndpoints(containerEndpoints)
             .setDefaultSidecarMemorySizeAttribute(defaultSidecarMemoryLimitBytes)
+            .setAttributes(kubernetesEnvironment.getAttributes())
             .build();
 
     InternalMachineConfig machineConfig = machineResolver.resolve();

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/MachineResolverBuilder.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/MachineResolverBuilder.java
@@ -13,6 +13,7 @@ package org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins;
 
 import io.fabric8.kubernetes.api.model.Container;
 import java.util.List;
+import java.util.Map;
 import org.eclipse.che.api.workspace.server.wsplugins.model.CheContainer;
 import org.eclipse.che.api.workspace.server.wsplugins.model.ChePluginEndpoint;
 
@@ -23,17 +24,23 @@ public class MachineResolverBuilder {
   private CheContainer cheContainer;
   private String defaultSidecarMemorySizeAttribute;
   private List<ChePluginEndpoint> containerEndpoints;
+  private Map<String, String> wsAttributes;
 
   public MachineResolver build() {
     if (container == null
         || cheContainer == null
         || defaultSidecarMemorySizeAttribute == null
+        || wsAttributes == null
         || containerEndpoints == null) {
       throw new IllegalStateException();
     }
 
     return new MachineResolver(
-        container, cheContainer, defaultSidecarMemorySizeAttribute, containerEndpoints);
+        container,
+        cheContainer,
+        defaultSidecarMemorySizeAttribute,
+        containerEndpoints,
+        wsAttributes);
   }
 
   public MachineResolverBuilder setContainer(Container container) {
@@ -54,6 +61,11 @@ public class MachineResolverBuilder {
 
   public MachineResolverBuilder setContainerEndpoints(List<ChePluginEndpoint> containerEndpoints) {
     this.containerEndpoints = containerEndpoints;
+    return this;
+  }
+
+  public MachineResolverBuilder setAttributes(Map<String, String> wsConfigAttributes) {
+    this.wsAttributes = wsConfigAttributes;
     return this;
   }
 }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/brokerphases/BrokerEnvironmentFactory.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/brokerphases/BrokerEnvironmentFactory.java
@@ -68,6 +68,7 @@ public abstract class BrokerEnvironmentFactory<E extends KubernetesEnvironment> 
 
   private final String cheWebsocketEndpoint;
   private final String pluginBrokerImage;
+  private final String brokerPullPolicy;
   private final AgentAuthEnableEnvVarProvider authEnableEnvVarProvider;
   private final MachineTokenEnvVarProvider machineTokenEnvVarProvider;
 
@@ -75,10 +76,12 @@ public abstract class BrokerEnvironmentFactory<E extends KubernetesEnvironment> 
   public BrokerEnvironmentFactory(
       @Named("che.websocket.endpoint") String cheWebsocketEndpoint,
       @Named("che.workspace.plugin_broker.image") String pluginBrokerImage,
+      @Named("che.workspace.plugin_broker.pull_policy") String brokerPullPolicy,
       AgentAuthEnableEnvVarProvider authEnableEnvVarProvider,
       MachineTokenEnvVarProvider machineTokenEnvVarProvider) {
     this.cheWebsocketEndpoint = cheWebsocketEndpoint;
     this.pluginBrokerImage = pluginBrokerImage;
+    this.brokerPullPolicy = brokerPullPolicy;
     this.authEnableEnvVarProvider = authEnableEnvVarProvider;
     this.machineTokenEnvVarProvider = machineTokenEnvVarProvider;
   }
@@ -136,7 +139,7 @@ public abstract class BrokerEnvironmentFactory<E extends KubernetesEnvironment> 
                 cheWebsocketEndpoint,
                 "-workspace-id",
                 workspaceId)
-            .withImagePullPolicy("Always")
+            .withImagePullPolicy(brokerPullPolicy)
             .withVolumeMounts(new VolumeMount(CONF_FOLDER + "/", BROKER_VOLUME, true, null))
             .withEnv(envVars.stream().map(this::asEnvVar).collect(toList()))
             .withNewResources()

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/brokerphases/KubernetesBrokerEnvironmentFactory.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/brokerphases/KubernetesBrokerEnvironmentFactory.java
@@ -38,11 +38,13 @@ public class KubernetesBrokerEnvironmentFactory
   public KubernetesBrokerEnvironmentFactory(
       @Named("che.websocket.endpoint") String cheWebsocketEndpoint,
       @Named("che.workspace.plugin_broker.image") String pluginBrokerImage,
+      @Named("che.workspace.plugin_broker.pull_policy") String brokerPullPolicy,
       AgentAuthEnableEnvVarProvider authEnableEnvVarProvider,
       MachineTokenEnvVarProvider machineTokenEnvVarProvider) {
     super(
         cheWebsocketEndpoint,
         pluginBrokerImage,
+        brokerPullPolicy,
         authEnableEnvVarProvider,
         machineTokenEnvVarProvider);
   }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/MachineResolverTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/MachineResolverTest.java
@@ -13,6 +13,7 @@ package org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins;
 
 import static com.google.common.collect.ImmutableMap.of;
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyMap;
 import static org.eclipse.che.api.core.model.workspace.config.MachineConfig.MEMORY_LIMIT_ATTRIBUTE;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
@@ -48,7 +49,8 @@ public class MachineResolverTest {
     endpoints = new ArrayList<>();
     cheContainer = new CheContainer();
     container = new Container();
-    resolver = new MachineResolver(container, cheContainer, DEFAULT_MEM_LIMIT, endpoints);
+    resolver =
+        new MachineResolver(container, cheContainer, DEFAULT_MEM_LIMIT, endpoints, emptyMap());
   }
 
   @Test

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/wsplugins/brokerphases/OpenshiftBrokerEnvironmentFactory.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/wsplugins/brokerphases/OpenshiftBrokerEnvironmentFactory.java
@@ -40,11 +40,13 @@ public class OpenshiftBrokerEnvironmentFactory
   public OpenshiftBrokerEnvironmentFactory(
       @Named("che.websocket.endpoint") String cheWebsocketEndpoint,
       @Named("che.workspace.plugin_broker.image") String pluginBrokerImage,
+      @Named("che.workspace.plugin_broker.pull_policy") String brokerPullPolicy,
       AgentAuthEnableEnvVarProvider authEnableEnvVarProvider,
       MachineTokenEnvVarProvider machineTokenEnvVarProvider) {
     super(
         cheWebsocketEndpoint,
         pluginBrokerImage,
+        brokerPullPolicy,
         authEnableEnvVarProvider,
         machineTokenEnvVarProvider);
   }

--- a/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
+++ b/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
@@ -104,6 +104,8 @@ public final class Constants {
    */
   public static final String WORKSPACE_TOOLING_PLUGINS_ATTRIBUTE = "plugins";
 
+  public static final String SIDECAR_MEMORY_LIMIT_ATTR_TEMPLATE = "sidecar-%s-memory_limit";
+
   /**
    * Describes workspace runtimes which perform start/stop of this workspace. Should be set/read
    * from {@link Workspace#getAttributes}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsplugins/model/CheContainer.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsplugins/model/CheContainer.java
@@ -20,6 +20,7 @@ import java.util.Objects;
 public class CheContainer {
 
   private String image = null;
+  private String name = null;
   private List<EnvVar> env = new ArrayList<>();
 
   @JsonProperty("editor-commands")
@@ -42,6 +43,19 @@ public class CheContainer {
 
   public void setImage(String image) {
     this.image = image;
+  }
+
+  public CheContainer name(String name) {
+    this.name = name;
+    return this;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
   }
 
   /** List of environment variables to set in the container. Cannot be updated. */
@@ -138,13 +152,14 @@ public class CheContainer {
         && Objects.equals(getCommands(), that.getCommands())
         && Objects.equals(getVolumes(), that.getVolumes())
         && Objects.equals(getPorts(), that.getPorts())
-        && Objects.equals(getMemoryLimit(), that.getMemoryLimit());
+        && Objects.equals(getMemoryLimit(), that.getMemoryLimit())
+        && Objects.equals(getName(), that.getName());
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(
-        getImage(), getEnv(), getCommands(), getVolumes(), getPorts(), getMemoryLimit());
+        getImage(), getEnv(), getCommands(), getVolumes(), getPorts(), getMemoryLimit(), getName());
   }
 
   @Override
@@ -163,6 +178,8 @@ public class CheContainer {
         + ports
         + ", memoryLimit="
         + memoryLimit
+        + ", name="
+        + name
         + '}';
   }
 }


### PR DESCRIPTION
### What does this PR do?
Allow overriding sidecar memory limit from a workspace config attributes.
Add an ability to change che-plugin-broker image pull policy which is useful for the development needs.

### What issues does this PR fix or reference?


#### Changelog
<!-- one line entry to be added to changelog -->

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
